### PR TITLE
FIX: Decrypt (wordArrayToByteArray) and compatibility

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -6,6 +6,7 @@ import BigInteger from "jsbn";
 import * as pako from "pako";
 import cryptoJs from "crypto-js";
 import hex from "crypto-js/enc-hex";
+import { Buffer } from "buffer";
 
 function rsConvert(address) {
   var addr = new NxtAddress();

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -205,7 +205,7 @@ function wordArrayToByteArray(wordArray, isFirstByteHasSign) {
   if (len == 0) {
     return new Array(0);
   }
-  var byteArray = new Array(wordArray.sigBytes);
+  var byteArray = new Array(len * 4);
   var offset = 0;
   var word;
   var i;
@@ -229,7 +229,8 @@ function wordArrayToByteArray(wordArray, isFirstByteHasSign) {
   if (wordArray.sigBytes % 4 > 2) {
     byteArray[offset++] = (word >> 8) & 0xff;
   }
-  return byteArray;
+
+  return byteArray.slice(0, wordArray.sigBytes);
 }
 
 function byteArrayToShortArray(byteArray) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 import cryptoJs from "crypto-js";
 import hex from "crypto-js/enc-hex";
 import { BigInteger } from "jsbn";
+import { Buffer } from "buffer";
 
 var charToNibble = {};
 var nibbleToChar = [];


### PR DESCRIPTION
Instead of creating a new byte array with the length of wordArray.sigBytes, you can create an array with length len * 4 and then cut the unneeded bytes at the end of the loop. This will avoid creating a larger array than necessary and thus reduce memory usage.

**It now returns the exact amount it needs and decryption works perfectly.**

On the other hand, `<Buffer>` was added to increase compatibility with other frameworks (in my case, ReactJS).